### PR TITLE
Added Private Routing Capability

### DIFF
--- a/src/components/elements/PrivateRoute/PrivateRoute.jsx
+++ b/src/components/elements/PrivateRoute/PrivateRoute.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Route, Redirect } from "react-router-dom";
+
+export const PrivateRoute = ({ component: Component, ...rest }) => {
+  return (
+    <Route
+      {...rest}
+      render={(props) => {
+        if (localStorage.getItem("token")) {
+          return <Component {...props} />;
+        } else {
+          return <Redirect to="/login" />;
+        }
+      }}
+    />
+  );
+};
+
+export default PrivateRoute;

--- a/src/components/elements/PrivateRoute/PrivateRoute.spec.jsx
+++ b/src/components/elements/PrivateRoute/PrivateRoute.spec.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { renderWithRouter } from "../../../utilities";
+import { PrivateRoute } from "./PrivateRoute";
+
+describe("Private Route", () => {
+  it("redirects to login page when no token is present in localStorage", () => {
+    // Arrange: Create a test component
+    const TestComponent = () => {
+      return <div>private content</div>;
+    };
+
+    // Act: Render the page after clearing localStorage
+    localStorage.clear();
+    renderWithRouter(<PrivateRoute component={TestComponent} />, true);
+
+    // Assert: Verify private content didn't load and user is redirected
+    const sensitiveContent = screen.queryByText(/private content/i);
+    expect(sensitiveContent).not.toBeInTheDocument();
+    expect(location.pathname).toEqual("/login");
+  });
+
+  it("renders a private page when 'token' exists in localStorage", () => {
+    // Arrange: Add a token to localStorage, and make a test component
+    localStorage.setItem("token", "testToken");
+    const TestComponent = () => {
+      return <div>private content</div>;
+    };
+
+    // Act: Render the page without clearing localStorage
+    renderWithRouter(<PrivateRoute component={TestComponent} />, true);
+
+    // Arrange: Verify that private content was loaded
+    const sensitiveContent = screen.queryByText(/private content/i);
+    expect(sensitiveContent).toBeInTheDocument();
+    localStorage.clear();
+  });
+});

--- a/src/components/elements/PrivateRoute/index.js
+++ b/src/components/elements/PrivateRoute/index.js
@@ -1,0 +1,1 @@
+export * from "./PrivateRoute";

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,4 +2,12 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";
+
+// Mock local storage for testing
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  clear: jest.fn(),
+};
+global.localStorage = localStorageMock;


### PR DESCRIPTION
### setupTests.js

- LocalStorage is now globally mocked across tests wherever Jest is used; just use localStorage like normal if you need to, and remember to clear it if looking for specific behavior

### PrivateRoute Component

- This component works just like `<Route/>`, but checks for a "token" in localStorage before routing
  - If no token is present, the user will be redirected to "/login" instead of their intended route
- This component passes unit testing in Jest for both the happy/sad paths; it should be ready for deployment where needed